### PR TITLE
ci: Do not run release-please in template repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,12 +14,14 @@ permissions:
 
 jobs:
   release-please:
+    # TODO: @memes - enable in real project
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
         uses: GoogleCloudPlatform/release-please-action@v4.0.2
         with:
-          # TODO @memes - make sure release-type and package-name are correct.
+          # TODO @memes - make sure release-type and other options are correct.
           release-type: simple
           # TODO @memes - If other actions are not going to be triggered by the
           # result of this action this can be removed.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ demos and projects.
 
 1. Use as a template when creating a new GitHub repo, or copy the contents into
    a bare-repo directory.
-
 2. Update `.pre-commit-config.yml` to add/remove plugins as necessary.
 3. Modify README.md and CONTRIBUTING.md, change LICENSE as needed.
 4. Review GitHub PR and issue templates.
@@ -22,6 +21,7 @@ demos and projects.
    1. In GitHub Settings:
       * _Settings_ > _Actions_ > _General_  > _Allow GitHub Actions to create and approve pull requests_ is checked
       * _Settings_ > _Secrets and Variables_ > _Actions_, and add `RELEASE_PLEASE_TOKEN` with PAT as a _Repository Secret_
-   2. Reset [version.txt](version.txt) to an empty file or remove if using a different `release-please` type.
+   2. Modify [release-please action](.github/workflows/release-please.yml) to have the correct release-type and enable
+   3. Reset [version.txt](version.txt) to an empty file or remove if using a different `release-please` type.
 6. Remove all [CHANGELOG](CHANGELOG.md) entries.
 7. Commit changes.


### PR DESCRIPTION
It doesn't make sense to create releases for the template repo, so the release-please action is disabled, with instructions added to README.